### PR TITLE
Simplify board generator, make thing run on windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "cursive"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +105,7 @@ dependencies = [
  "ahash",
  "cfg-if",
  "crossbeam-channel",
+ "crossterm",
  "cursive_core",
  "lazy_static",
  "libc",
@@ -274,6 +306,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +326,18 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "ncurses"
@@ -384,6 +438,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +489,21 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -444,6 +536,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +554,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "stable_deref_trait"
@@ -571,6 +680,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "xi-unicode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ categories = ["games"]
 
 [dependencies]
 aglet = "0.5.1"
-cursive = "0.20.0"
 fastrand = "2.0.1"
 itertools = "0.12.0"
+
+[target.'cfg(windows)'.dependencies.cursive]
+version = "0.20.0"
+default-features = false
+features = ["crossterm-backend"]
+
+[target.'cfg(unix)'.dependencies.cursive]
+version = "0.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ version = "0.20.0"
 default-features = false
 features = ["crossterm-backend"]
 
-[target.'cfg(unix)'.dependencies.cursive]
+[target.'cfg(not(windows))'.dependencies.cursive]
 version = "0.20.0"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -27,10 +27,10 @@ pub fn generate(w: u32, h: u32, seed: u64) -> Board {
   (0..w).for_each(|x| {
     (0..h).for_each(|y| {
       let directions =
-          get_single_direction_set(&horizontal_edges, Direction4::North, x, y) |
-              get_single_direction_set(&horizontal_edges, Direction4::South, x, y + 1) |
-              get_single_direction_set(&vertical_edges, Direction4::West, x, y) |
-              get_single_direction_set(&vertical_edges, Direction4::East, x + 1, y);
+          get_single_direction_set(horizontal_edges.get_or_default(x, y), Direction4::North) |
+              get_single_direction_set(horizontal_edges.get_or_default(x, y + 1), Direction4::South) |
+              get_single_direction_set(vertical_edges.get_or_default(x, y), Direction4::West) |
+              get_single_direction_set(vertical_edges.get_or_default(x + 1, y), Direction4::East);
 
       grid.insert(Coord::new(x, y), Cell::new(directions).spin(rng.i32(0..4)));
     })
@@ -44,16 +44,22 @@ fn generate_edge(rng: &mut Rng, x: u32, y: u32) -> Edge {
   return Edge::from(rng.bool())
 }
 
-fn get_single_direction_set(edges: &Grid<Edge>, direction: Direction4, x: u32, y: u32) -> Direction4Set {
-  if get_edge(edges, x, y) == Lit {
+fn get_single_direction_set(edge: Edge, direction: Direction4) -> Direction4Set {
+  if edge == Lit {
     Direction4Set::from(direction)
   } else {
     Direction4Set::empty()
   }
 }
 
-fn get_edge(edges: &Grid<Edge>, x: u32, y: u32) -> Edge {
-  edges.get(Coord::new(x, y)).copied().unwrap_or_default()
+trait GetOrDefaultByCoords<T : Default> {
+  fn get_or_default(&self, x: u32, y: u32) -> T;
+}
+
+impl<T> GetOrDefaultByCoords<T> for Grid<T> {
+  fn get_or_default(&self, x: u32, y: u32) -> T {
+    self.get(Coord::new(x, y)).copied().unwrap_or_default()
+  }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -72,4 +78,3 @@ impl From<bool> for Edge {
     }
   }
 }
-

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,132 +1,81 @@
-use aglet::{Area, Coord, Direction4, Direction4Set, Grid};
+use aglet::{Coord, Direction4, Direction4Set, Grid};
 use fastrand::Rng;
-use itertools::Itertools;
 
 use crate::board::{Board, Cell};
+use crate::generate::Edge::{Lit, Unlit};
 
 pub fn generate(w: u32, h: u32, seed: u64) -> Board {
-  for seed_offset in 0u64.. {
-    let board_mb = generate_inner(w, h, seed + seed_offset);
-    match board_mb {
-      Ok(board) => return board,
-      Err(ono) => eprintln!("{}", ono),
-    }
+  let mut rng = Rng::with_seed(seed);
+
+  let mut vertical_edges = Grid::new(w + 1, h);
+  let mut horizontal_edges = Grid::new(w, h + 1);
+
+  (1..w).for_each(|x| {
+    (0..h).for_each(|y| {
+      vertical_edges.insert(Coord::new(x, y), generate_edge(&mut rng, x, y));
+    })
+  });
+
+  (0..w).for_each(|x| {
+    (1..h).for_each(|y| {
+      horizontal_edges.insert(Coord::new(x, y), generate_edge(&mut rng, x, y));
+    })
+  });
+
+  let mut grid = Grid::new(w, h);
+
+  (0..w).for_each(|x| {
+    (0..h).for_each(|y| {
+      let directions =
+          get_single_direction_set(&horizontal_edges, Direction4::North, x, y) |
+              get_single_direction_set(&horizontal_edges, Direction4::South, x, y + 1) |
+              get_single_direction_set(&vertical_edges, Direction4::West, x, y) |
+              get_single_direction_set(&vertical_edges, Direction4::East, x + 1, y);
+
+      grid.insert(Coord::new(x, y), Cell::new(rotate_directions(&mut rng, directions)));
+    })
+  });
+
+  return Board::new(grid);
+}
+
+#[allow(unused_variables)]
+fn generate_edge(rng: &mut Rng, x: u32, y: u32) -> Edge {
+  return Edge::from(rng.bool())
+}
+
+fn get_single_direction_set(edges: &Grid<Edge>, direction: Direction4, x: u32, y: u32) -> Direction4Set {
+  if get_edge(edges, x, y) == Lit {
+    Direction4Set::from(direction)
+  } else {
+    Direction4Set::empty()
   }
-  unreachable!()
+}
+
+fn rotate_directions(rng: &mut Rng, directions: Direction4Set) -> Direction4Set {
+  let rotation = rng.i32(0..4);
+
+  directions.iter().map(|d| d.rotate_by(rotation)).collect()
+}
+
+fn get_edge(edges: &Grid<Edge>, x: u32, y: u32) -> Edge {
+  edges.get(Coord::new(x, y)).copied().unwrap_or_default()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum Edge {
   #[default]
-  Unknown,
   Unlit,
   Lit,
 }
 
-impl Edge {
-  fn valid_fits(other: Option<Edge>) -> &'static [Edge] {
-    match other {
-      Some(Edge::Unknown) => &[Edge::Unlit, Edge::Lit],
-      Some(Edge::Lit) => &[Edge::Lit],
-      Some(Edge::Unlit) => &[Edge::Unlit],
-      // poking out of bounds
-      None => &[Edge::Unlit],
+impl From<bool> for Edge {
+  fn from(value: bool) -> Self {
+    if value {
+      Lit
+    } else {
+      Unlit
     }
   }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-struct GenCell {
-  edges: [Edge; 4],
-}
-
-struct WfcBoard {
-  grid: Grid<GenCell>,
-  rng: Rng,
-}
-
-impl WfcBoard {
-  fn new(w: u32, h: u32, seed: u64) -> Self {
-    let rng = Rng::with_seed(seed);
-    let mut grid = Grid::new(w, h);
-    for x in 0..w {
-      for y in 0..h {
-        grid.insert(Coord::new(x, y), GenCell::default());
-      }
-    }
-
-    WfcBoard { grid, rng }
-  }
-
-  fn collapse(&mut self, pos: Coord) -> bool {
-    let here = *self.grid.get_or_insert(pos, GenCell::default());
-
-    let picked_edges = Direction4::DIRECTIONS
-      .into_iter()
-      .map(|dir| {
-        let edge = here.edges[dir.ordinal()];
-        if edge != Edge::Unknown {
-          return edge;
-        }
-        let neighbor_edge = pos
-          .offset4(dir)
-          .and_then(|npos| self.grid.get(npos))
-          .map(|cell| cell.edges[dir.flip().ordinal()]);
-        let ok_edges = Edge::valid_fits(neighbor_edge);
-        // Here is where the collapse happens
-        ok_edges[self.rng.usize(0..ok_edges.len())]
-      })
-      .collect_vec();
-    let picked_edges: [Edge; 4] = picked_edges.try_into().unwrap();
-    debug_assert!(!picked_edges.contains(&Edge::Unknown));
-
-    let cell = GenCell {
-      edges: picked_edges,
-    };
-    self.grid.insert(pos, cell);
-    true
-  }
-}
-
-fn generate_inner(w: u32, h: u32, seed: u64) -> Result<Board, String> {
-  let mut wfc = WfcBoard::new(w, h, seed);
-  let to_collapse = {
-    let mut cells = Area::new(Coord::ZERO, w, h).into_iter().collect_vec();
-    wfc.rng.shuffle(&mut cells);
-    cells
-  };
-
-  for &coord in to_collapse.iter() {
-    wfc.collapse(coord);
-  }
-
-  let mut out = Grid::<Cell>::new(w, h);
-  // might as well reuse the old vec
-  for &coord in to_collapse.iter() {
-    let wfc_cell = wfc
-      .grid
-      .get(coord)
-      .ok_or_else(|| format!("had no wfc cell at all at {}", coord))?;
-
-    let mut dirs = Direction4Set::empty();
-    for dir in Direction4::DIRECTIONS {
-      let wfc_edge = wfc_cell.edges[dir.ordinal()];
-      let edge_on = match wfc_edge {
-        Edge::Unlit => false,
-        Edge::Lit => true,
-        Edge::Unknown => {
-          return Err(format!("found uncollapsed edge at {}, {:?}", coord, dir))
-        }
-      };
-      if edge_on {
-        dirs |= dir;
-      }
-    }
-
-    let cell = Cell::new(dirs);
-    let cell = cell.spin(wfc.rng.i32(0..=3));
-    out.insert(coord, cell);
-  }
-
-  Ok(Board::new(out))
-}

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -32,7 +32,7 @@ pub fn generate(w: u32, h: u32, seed: u64) -> Board {
               get_single_direction_set(&vertical_edges, Direction4::West, x, y) |
               get_single_direction_set(&vertical_edges, Direction4::East, x + 1, y);
 
-      grid.insert(Coord::new(x, y), Cell::new(rotate_directions(&mut rng, directions)));
+      grid.insert(Coord::new(x, y), Cell::new(directions).spin(rng.i32(0..4)));
     })
   });
 
@@ -50,12 +50,6 @@ fn get_single_direction_set(edges: &Grid<Edge>, direction: Direction4, x: u32, y
   } else {
     Direction4Set::empty()
   }
-}
-
-fn rotate_directions(rng: &mut Rng, directions: Direction4Set) -> Direction4Set {
-  let rotation = rng.i32(0..4);
-
-  directions.iter().map(|d| d.rotate_by(rotation)).collect()
 }
 
 fn get_edge(edges: &Grid<Edge>, x: u32, y: u32) -> Edge {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -24,16 +24,14 @@ pub fn generate(w: u32, h: u32, seed: u64) -> Board {
 
   let mut grid = Grid::new(w, h);
 
-  (0..w).for_each(|x| {
-    (0..h).for_each(|y| {
-      let directions =
-          get_single_direction_set(horizontal_edges.get_or_default(x, y), Direction4::North) |
-              get_single_direction_set(horizontal_edges.get_or_default(x, y + 1), Direction4::South) |
-              get_single_direction_set(vertical_edges.get_or_default(x, y), Direction4::West) |
-              get_single_direction_set(vertical_edges.get_or_default(x + 1, y), Direction4::East);
+  grid.area().into_iter().for_each(|Coord { x, y }| {
+    let directions =
+      get_single_direction_set(horizontal_edges.get_or_default(x, y), Direction4::North) |
+        get_single_direction_set(horizontal_edges.get_or_default(x, y + 1), Direction4::South) |
+        get_single_direction_set(vertical_edges.get_or_default(x, y), Direction4::West) |
+        get_single_direction_set(vertical_edges.get_or_default(x + 1, y), Direction4::East);
 
-      grid.insert(Coord::new(x, y), Cell::new(directions).spin(rng.i32(0..4)));
-    })
+    grid.insert(Coord::new(x, y), Cell::new(directions).spin(rng.i32(0..4)));
   });
 
   return Board::new(grid);
@@ -52,11 +50,11 @@ fn get_single_direction_set(edge: Edge, direction: Direction4) -> Direction4Set 
   }
 }
 
-trait GetOrDefaultByCoords<T : Default> {
+trait GetOrDefaultByCoords<T> where T: Default, T: Copy {
   fn get_or_default(&self, x: u32, y: u32) -> T;
 }
 
-impl<T> GetOrDefaultByCoords<T> for Grid<T> {
+impl<T> GetOrDefaultByCoords<T> for Grid<T> where T: Default, T: Copy {
   fn get_or_default(&self, x: u32, y: u32) -> T {
     self.get(Coord::new(x, y)).copied().unwrap_or_default()
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
-use aglet::Coord;
 use cursive::{
   views::{
-    Button, Dialog, Layer, LinearLayout, NamedView, OnEventView, Panel,
-    SliderView, TextView,
+    Button, Dialog, LinearLayout, NamedView, OnEventView, Panel, TextView,
   },
   Cursive, View,
 };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,14 +3,11 @@ use cursive::{
   direction::Direction,
   event::{Event, EventResult, Key},
   theme::{
-    BaseColor, BorderStyle, Color, ColorStyle, Effect, Palette, PaletteStyle,
-    Style, Theme,
+    BorderStyle, Color, ColorStyle, Effect, Palette, PaletteStyle,
+    Theme,
   },
   view::{CannotFocus, ViewWrapper},
-  views::{
-    Button, Dialog, LinearLayout, NamedView, Panel, SliderView, TextView,
-  },
-  Cursive, Printer, Vec2, View, With,
+  Printer, Vec2, View, With,
 };
 
 use crate::board::{Board, Cell};


### PR DESCRIPTION
`generate_edge` takes coords, unused but could be used for weighted generation maybe.

ncurses doesn't build on windows, replace with crossterm. `pancurses-backend` wouldn't require cfg dependencies but is sadly completely broken.
![image](https://github.com/gamma-delta/ttyloop/assets/8020624/d8c21d93-c7db-478f-9897-d1e4adf9f02c)
